### PR TITLE
Update pg_config for newer PostgreSQL versions

### DIFF
--- a/pgbdd/pg_config.h
+++ b/pgbdd/pg_config.h
@@ -31,7 +31,7 @@
 
 //
 
-#define DatumGetDictionary(x)        bdd_dictionary_relocate(((bdd_dictionary *) DatumGetPointer(x)))
+#define DatumGetDictionary(x)        bdd_dictionary_relocate(((bdd_dictionary *) x))
 
 #define PG_GETARG_DICTIONARY(x)      DatumGetDictionary(          \
                 PG_DETOAST_DATUM(PG_GETARG_DATUM(x)))
@@ -46,7 +46,7 @@
 
 //
 
-#define DatumGetBdd(x)        relocate_bdd(((bdd *) DatumGetPointer(x)))
+#define DatumGetBdd(x)        relocate_bdd(((bdd *) x))
 
 #define PG_GETARG_BDD(x)      DatumGetBdd(          \
                 PG_DETOAST_DATUM(PG_GETARG_DATUM(x)))


### PR DESCRIPTION
You don't need to merge this PR, you can just leave it open. If the castle ever wants to update to a newer version of Postgres, this change will be needed. I believe for Postgres 15 and higher this change is required.