### PR TITLE
Increase size of node index

### DIFF
--- a/pgbdd/bdd.h
+++ b/pgbdd/bdd.h
@@ -42,16 +42,10 @@ int cmpRva(rva*, rva*);
  * Decision Diagrams" by HR Andersen.
  *
  * https://www.cmi.ac.in/~madhavan/courses/verification-2011/andersen-bdd.pdf
- *
- * The current implementation defines a node index type 'nodei' as a regular
- * short with the NODEI_NONE = -1. This can be made larger by making it
- * unsigned but BDD's of more than 32767 are too large to handle anyway I
- * think. And in this case NODEI_NONE would be USHRT_MAX and NODEI_MAX would
- * be USHRT_MAX-1
  */
 
-typedef short      nodei;
-#define NODEI_MAX  SHRT_MAX
+typedef int32_t    nodei;
+#define NODEI_MAX  INT32_MAX
 #define NODEI_NONE -1
 
 typedef struct rva_node {


### PR DESCRIPTION
Increase the size of the `nodei` type. I need this for an experiment with a BDD that's around 1MB in size, which does not work with the current size.

I tried implementing the suggestion in the comment by changing it to `USHRT_MAX`, with setting `NODEI_MAX` to `SHRT_MAX-1` but this did not work immediately and I was not able to figure out how to get that working.

Just upgrading it to a 32 bit signed integer works though.