### PR TITLE
Add conversion from postgres bytea to bdd type

### DIFF
--- a/pgbdd/pg_bdd.c
+++ b/pgbdd/pg_bdd.c
@@ -40,6 +40,21 @@ bdd_in(PG_FUNCTION_ARGS)
     PG_RETURN_BDD(return_bdd);
 }
 
+PG_FUNCTION_INFO_V1(bdd_bytea_in);
+/**
+ * <code>bdd_bytea_in(expression bytea) returns bdd</code>
+ * Create an expression from struct byte array.
+ *
+ */
+Datum
+bdd_bytea_in(PG_FUNCTION_ARGS)
+{
+    bytea *input_bytea = PG_GETARG_BYTEA_P(0);
+    bdd *return_bdd = (bdd*) VARDATA_ANY(input_bytea);
+    SET_VARSIZE(return_bdd,return_bdd->bytesize);
+    PG_RETURN_BDD(return_bdd);
+}
+
 PG_FUNCTION_INFO_V1(bdd_out);
 /**
  * <code>bdd_out(bdd bdd) returns text</code>

--- a/pgbdd/pgbdd--0.0.1.sql
+++ b/pgbdd/pgbdd--0.0.1.sql
@@ -21,6 +21,13 @@ function bdd_in(expression cstring) returns bdd
 comment on function bdd_in(cstring) is
 'Create a bdd expression from argument string.';
 
+create
+function bdd_bytea_in(expression bytea) returns bdd
+     as '$libdir/pgbdd', 'bdd_bytea_in'
+     language C immutable strict;
+comment on function bdd_bytea_in(bytea) is
+'Create a bdd expression from argument byte array.';
+
 create 
 function bdd_out(dict bdd) returns cstring
      as '$libdir/pgbdd', 'bdd_out'
@@ -37,6 +44,10 @@ CREATE TYPE bdd (
 );
 comment on type bdd is
 'A postgres implementation of a Binary Decision Diagrams.';
+
+create cast (bytea as bdd)
+with function bdd_bytea_in(bytea)
+as implicit;
 
 create 
 function _op_bdd(operator cstring,lhs_bdd bdd,rhs_bdd bdd) returns bdd


### PR DESCRIPTION
This adds a conversion function in postgres that allows us to convert byte array types to the BDD type by just casting it directly. This was needed to support ingestion of large BDDs, where just using the expression string is not feasible. In my case this is to ingest a BDD that's 1MB in size into the database.